### PR TITLE
Fixes needed to work with NCrystal v2.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 
 #Standard build, need NCrystal as dependency:
 
-find_package(NCrystal 2.4.0 REQUIRED)
+find_package(NCrystal 2.4.81 REQUIRED)
 
 if ( NCPLUGIN_DEVMODE )
   #Compile with very strict C++11 options during normal development (this gives

--- a/include/NCPhysicsModel.hh
+++ b/include/NCPhysicsModel.hh
@@ -31,12 +31,12 @@ namespace NCPluginNamespace {
     //Provide cross sections for a given neutron:
     double calcCrossSection( double neutron_ekin ) const;
     //Sample scattering vector from inverse CDF (rng is random number stream).
-    double sampleScatteringVector( NC::RandomBase& rng, double neutron_ekin ) const;
+    double sampleScatteringVector( NC::RNG& rng, double neutron_ekin ) const;
 
     //Sample scattering event. Results are given
     //as the final ekin of the neutron and scat_mu which is cos(scattering_angle).
     struct ScatEvent { double ekin_final, mu; };
-    ScatEvent sampleScatteringEvent( NC::RandomBase& rng, double neutron_ekin ) const;
+    ScatEvent sampleScatteringEvent( NC::RNG& rng, double neutron_ekin ) const;
 
   private:
     //Data members:

--- a/include/NCPluginFactory.hh
+++ b/include/NCPluginFactory.hh
@@ -10,11 +10,11 @@ namespace NCPluginNamespace {
   //Factory which implements logic of how the physics model provided by the
   //plugin should be combined with existing models in NCrystal:
 
-  class PluginFactory final : public NC::FactoryBase {
+  class PluginFactory final : public NC::FactImpl::ScatterFactory {
   public:
-    const char * getName() const final;
-    int canCreateScatter( const NC::MatCfg& ) const final;
-    NC::RCHolder<const NC::Scatter> createScatter( const NC::MatCfg& ) const final;
+    const char * name() const noexcept override;
+    NC::Priority query( const NC::MatCfg& ) const override;
+    NC::ProcImpl::ProcPtr produce( const NC::MatCfg& ) const override;
   };
 }
 

--- a/src/NCPhysicsModel.cc
+++ b/src/NCPhysicsModel.cc
@@ -85,7 +85,7 @@ double NCP::PhysicsModel::calcCrossSection( double neutron_ekin ) const
   return total_sigma;
 }
 
-double NCP::PhysicsModel::sampleScatteringVector( NC::RandomBase& rng, double neutron_ekin ) const 
+double NCP::PhysicsModel::sampleScatteringVector( NC::RNG& rng, double neutron_ekin ) const 
 {
   double rand = rng.generate();
   double Q;
@@ -99,13 +99,12 @@ double NCP::PhysicsModel::sampleScatteringVector( NC::RandomBase& rng, double ne
     Q = std::pow((rand/ratio_sigma - (m_A1/(m_b1+2))*std::pow(m_Q0,m_b1+2) + (m_A2/(m_b2+2))*std::pow(m_Q0,m_b2+2))*(m_b2+2)/m_A2, 1/(m_b2+2));
   }
 
-  
   return Q;
 }
-NCP::PhysicsModel::ScatEvent NCP::PhysicsModel::sampleScatteringEvent( NC::RandomBase& rng, double neutron_ekin ) const
+NCP::PhysicsModel::ScatEvent NCP::PhysicsModel::sampleScatteringEvent( NC::RNG& rng, double neutron_ekin ) const
 {
   ScatEvent result;
-  
+
   //section for energy limits
   /*if ( ! (neutron_ekin > 1) ) {
     result.ekin_final = neutron_ekin;

--- a/src/NCPluginBoilerPlate.cc
+++ b/src/NCPluginBoilerPlate.cc
@@ -10,8 +10,8 @@
 
 void NCP::registerPlugin()
 {
-  //This function is required for the plugin to work. It should register factories (or
-  //potentially other stuff, e.g. adding in-mem data files, etc.) for the
-  //plugin.
-  NC::registerFactory(std::make_unique<NCP::PluginFactory>());
+  //This function is required for the plugin to work. It should register
+  //factories (or potentially other stuff, e.g. adding in-mem data files, etc.)
+  //for the plugin.
+  NC::FactImpl::registerFactory(std::make_unique<NCP::PluginFactory>());
 };

--- a/testcode/app_simpletest/main.cc
+++ b/testcode/app_simpletest/main.cc
@@ -14,7 +14,7 @@ int main()
               << pm.calcCrossSection( NC::wl2ekin(wl) ) <<" barn" << std::endl;
   }
 
-  auto rng = NC::defaultRNG();
+  auto rng = NC::getRNG();
 
   for ( auto wl : NC::linspace(9, 11, 2) ) {
     for (unsigned i = 0; i < 10; ++i) {

--- a/testcode/src/NCExtraTestUtils.cc
+++ b/testcode/src/NCExtraTestUtils.cc
@@ -4,8 +4,8 @@ std::vector<double> NCPluginTestCode::sampleAngles( const NCP::PhysicsModel& pm,
 {
   std::vector<double> angles;
   angles.reserve(nvalues);
-  auto rng = NC::defaultRNG();
+  auto rng = NC::getRNG();
   for (unsigned i = 0; i < nvalues; ++i)
-    angles.push_back( std::acos( pm.sampleScatteringEvent(*rng,ekin).mu ) );
+    angles.push_back( std::acos( pm.sampleScatteringEvent(rng,ekin).mu ) );
   return angles;
 }

--- a/testcode/src/NCForPython.cc
+++ b/testcode/src/NCForPython.cc
@@ -17,9 +17,9 @@ extern "C" {
   void nctest_samplemanyscatmu( double A1, double b1, double A2, double b2, double Q0, double sigma0, double ekin, unsigned nvalues, double* output_mu )
   {
     NCP::PhysicsModel pm(A1,  b1,  A2,  b2,  Q0,  sigma0);
-    auto rng = NC::defaultRNG();
+    auto rng = NC::getRNG();
     for (unsigned i = 0; i < nvalues; ++i)
-      output_mu[i] = pm.sampleScatteringEvent(*rng,ekin).mu;
+      output_mu[i] = pm.sampleScatteringEvent(rng,ekin).mu;
   }
 
 }


### PR DESCRIPTION
Update plugin for NCrystal v2.5.0.

Btw. note that NCrystal v2.5.0 is not released yet (1-2 days to go), so on the off chance that you need to work on the plugin in that brief period, just use the develop branch of the NCrystal repo.